### PR TITLE
feat: 채팅기능 및 로그인, 마이페이지, 필요한 api들 구현 (테스트 전)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ const App = () => {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/mypage" element={<MyPage />} />
+          <Route path="/workspace/:spaceId" element={<WorkPlacePage />} />
           <Route path="/workspace" element={<WorkPlacePage />} />
           <Route path="/chat" element={<ChatTestPage />} />
         </Routes>

--- a/frontend/src/api/chatApi.js
+++ b/frontend/src/api/chatApi.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const getChatMessages = async (spaceId) => {
     try {
-        const response = await axios.get(`서버ip/api/${spaceId}`);
+        const response = await axios.get(`https://letsnote-rough-wind-6773.fly.dev/api/${spaceId}`);
         return response.data;  // response에 메시지 리스트 포함
     } catch (error) {
         console.error('getChatMessages 에러:', error);   

--- a/frontend/src/api/loginApi.js
+++ b/frontend/src/api/loginApi.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const login = async (userId, password) => {
+    try {        
+        const response = await axios.post('https://letsnote-rough-wind-6773.fly.dev/api/v1/accounts/token', {
+            username: userId,
+            password: password
+        });        
+        return response.data; 
+    } catch (error) {
+        console.error('로그인 요청 오류:', error);        
+    }
+}
+
+export default login;

--- a/frontend/src/api/myPageApi.js
+++ b/frontend/src/api/myPageApi.js
@@ -1,19 +1,28 @@
-/* 
-마이페이지 진입시 요청할 데이터들: 
-
-*/
 import axios from 'axios';
 
-const getMyPageInfo = async (userId) => {
+const getMyPageInfo = async (accessToken) => {
     try {
-        const response = await axios.post('서버ip/api', {
-            spaceId: spaceId,
-            snapshotId: snapshotId,
+        const response = await axios.get('https://letsnote-rough-wind-6773.fly.dev/api/v1/workspaces', {
+            headers: {
+                Authorization: `Bearer ${accessToken}`
+            }
         });
-        return response.data; 
+        return response.data;
     } catch (error) {
-        console.error('getMyPageInfo 에러:', error);   
+        console.error('getMyPageInfo 요청 오류:', error);        
     }
 }
 
+const createWorkSpace = async (accessToken) => {
+    try {
+        const response = await axios.post('https://letsnote-rough-wind-6773.fly.dev/api/v1/workspaces',{
+            accesstoken: accessToken,        
+        });
+        return response.data;
+    } catch (error) {
+        console.error('createWorkSpace 요청 오류:', error);
+    }
+}
+
+export { createWorkSpace };
 export default getMyPageInfo;

--- a/frontend/src/app/slices/chatSlice.js
+++ b/frontend/src/app/slices/chatSlice.js
@@ -1,10 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import getChatMessages from '../../api/chatApi';
 
-/* 
-getChatMessages는 createAsyncThunk를 사용하여 정의된 비동기 액션입니다. 
-이 함수는 chatApi.js에 정의된 getChatMessages API 함수를 호출하고, 그 결과(응답)를 반환합니다.
-*/
+// createAsyncThunk를 사용하여 처음 작업실 입장시 채팅 기록 가져오는 걸 비동기로 처리
 const fetchChatMessages = createAsyncThunk(
   'chat/fetchChatMessages',
   async (spaceId) => {
@@ -16,20 +13,27 @@ const fetchChatMessages = createAsyncThunk(
 const chatSlice = createSlice({
   name: 'chat',
   initialState: {
-    spaces: {}, // 채팅방별 메시지와 상태 관리
+    spaces: {}, // 작업실별 메시지와 상태 관리
   },
   reducers: {
-    // 여기에 채팅 관련 리듀서 추가
+    addMessage: (state, action) => {
+      const { spaceId, message } = action.payload;
+      if (!state.spaces[spaceId]) {
+        state.spaces[spaceId] = [];
+      }
+      state.spaces[spaceId].push(message);
+    },    
   },
-  // createSlice에서 정의된 일반 액션(reducers)과 별도로, 외부(createAsyncThunk)에 의해 생성된 비동기 액션 처리
+
+  // createAsyncThunk에 의해 생성된 비동기 액션 처리.   
   extraReducers: (builder) => {
     builder.addCase(fetchChatMessages.fulfilled, (state, action) => {
       const { spaceId, messages } = action.payload;
       state.spaces[spaceId] = messages;
     });
-    // 기타 액션 핸들러...
   },
 });
 
+export const { addMessage } = chatSlice.actions;
 export { fetchChatMessages };
 export default chatSlice.reducer;

--- a/frontend/src/components/Chat/ChatInput.jsx
+++ b/frontend/src/components/Chat/ChatInput.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useState } from 'react';
 import styled from 'styled-components';
-import socket from '../../utils/io';
 
-// 스타일드 컴포넌트 생성
 const InputArea = styled.div`
   background-color: red;
   min-height: 50px;
@@ -59,22 +57,19 @@ const StyledButton = styled.button`
 `;
 
 
-const ChatInput = () => {
+const ChatInput = ({ onSendMessage }) => {
   const [message, setMessage] = useState("");
-  
-  // socket으로 메시지 전송
-  const sendMessage = (event) => {
+
+  const handleSubmit = (event) => {
     event.preventDefault();
-    if (message) {
-      socket.emit("sendMessage", message); // 메시지 전송
-      setMessage(""); // 입력 필드 초기화
-    }
-  }
+    onSendMessage(message);
+    setMessage(''); // 입력 필드 다시 초기화
+  };
 
   return (
     <InputArea>
       <PlusButton>+</PlusButton>
-      <InputContainer onSubmit={sendMessage}>
+      <InputContainer onSubmit={handleSubmit}>
         <StyledInput
           type="text"
           placeholder="채팅을 입력하세요"
@@ -84,7 +79,7 @@ const ChatInput = () => {
 
         <StyledButton
           disabled={message === ""}
-          type="submit"
+          type="submit"          
         >
           전송
         </StyledButton>

--- a/frontend/src/components/Chat/ChatMessage.jsx
+++ b/frontend/src/components/Chat/ChatMessage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import socket from '../../utils/io';
+// import socket from '../../utils/io';
 
 const StyledContainer = styled.div`
   padding: 10px; 
@@ -57,53 +57,53 @@ const ProfileImage = styled.img`
   margin-right: 10px;
 `;
 
-const ChatMessage = ({ messageList, user }) => {
-    const [localMessageList, setLocalMessageList] = useState([]);
+// 확인 필요: 메시지에 담겨오는 유저 정보가 닉네임인지 다른 userId인지?
+// 내가 prop으로 넘겨와서 비교중인건 닉네임. 다르면 수정 필요
+const ChatMessage = ({ messageList = [], nickname }) => {
+    const [localMessageList, setLocalMessageList] = useState(messageList);
 
-    // 받아오는 
     useEffect(() => {
-        socket.on("receiveMessage", (message) => {
-            setLocalMessageList(prev => [...prev, message]);
-        });
+        // WebSocket 구독 로직은 WebSocketContainer에서 처리되므로, 여기서는 Redux 상태를 감시
+        setLocalMessageList(messageList);
+    }, [messageList]);
 
-        return () => {
-            socket.off("receiveMessage");
-        }
-    },[]);
+    // 만약에 작업실 안에서 보낸 메시지가 포함이 안되면, 로컬에서 처리하는 식으로 바꾸기
 
     return (
         <div>
             {localMessageList.map((message, index) => {
                 return (
                     <StyledContainer key={message._id}>
-                        {message.user.name === "system" ? (
-                            <SystemMessageContainer>
-                                <SystemMessage>{message.chat}</SystemMessage>
-                            </SystemMessageContainer>
-                        ) : message.user.name === user.name ? (
-                            <MyMessageContainer>
-                                {user.name}
-                                <MyMessage>{message.chat}</MyMessage>
-                                {/* {message.time} */}
-                            </MyMessageContainer>
-                        ) : (
-                            <OthersMessageContainer>
-                                <ProfileImage
+                        {
+                            // message.nickname === "system" ? (
+                            //     <SystemMessageContainer>
+                            //         <SystemMessage>{message.chat}</SystemMessage>
+                            //     </SystemMessageContainer>
+                            // ) : 
+                            message.user.nickname === nickname ? (
+                                <MyMessageContainer>
+                                    {nickname}
+                                    <MyMessage>{message.chat}</MyMessage>
+                                    {message.timestamp}
+                                </MyMessageContainer>
+                            ) : (
+                                <OthersMessageContainer>
+                                    {/* <ProfileImage
                                     src="/profile.jpeg"
                                     style={
                                         (index === 0
                                             ? { visibility: "visible" }
-                                            : messageList[index - 1].user.name === user.name) ||
-                                            messageList[index - 1].user.name === "system"
+                                            : messageList[index - 1].user.nickname === user.name) ||
+                                            messageList[index - 1].user.nickname === "system"
                                             ? { visibility: "visible" }
                                             : { visibility: "hidden" }
                                     }
-                                />
-                                {user.name}
-                                <OthersMessage>{message.chat}</OthersMessage>
-                                {/* {message.time} */}
-                            </OthersMessageContainer>
-                        )}
+                                /> */}
+                                    {message.user.nickname}
+                                    <OthersMessage>{message.chat}</OthersMessage>
+                                    {message.timestamp}
+                                </OthersMessageContainer>
+                            )}
                     </StyledContainer>
                 );
             })}

--- a/frontend/src/containers/workplace/ChatContainer.jsx
+++ b/frontend/src/containers/workplace/ChatContainer.jsx
@@ -4,6 +4,7 @@ import { fetchChatMessages } from '../../app/slices/chatSlice';
 import styled from 'styled-components'
 import ChatInput from '../../components/Chat/ChatInput';
 import ChatMessage from '../../components/Chat/ChatMessage';
+import { sendMessage } from '../WebSocket/WebSocketContainer';
 
 const StyledChatContainer = styled.div`
     height: 100vh;   
@@ -26,12 +27,16 @@ const ChatContainer = ({ spaceId }) => {
     }, [dispatch, spaceId]); // 작업실이 바뀌면 메시지 목록 새로 받아오기
 
     // 로컬스토리지에서 닉네임 꺼내기
-    // const nickname = localStorage.getItem("nickname");
+    const nickname = localStorage.getItem("nickname");
+
+    const handleSendMessage = (message) => {
+        sendMessage(spaceId, nickname, message);
+    }
 
     return (
         <StyledChatContainer>
-            <ChatMessage messageList={chatMessages/* .메시지 목록 */} user={"임시닉넴"} />
-            <ChatInput />
+            <ChatMessage messageList={chatMessages} nickname={nickname} />
+            <ChatInput onSendMessage={handleSendMessage} />
         </StyledChatContainer>
     )
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,12 +1,67 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import login from '../api/loginApi';
 
 const LandingPage = () => {
-    const navigate = useNavigate();    
+    const navigate = useNavigate(); 
+    const [userId, setUserId] = useState('');
+    const [password, setPassword] = useState('');
+
+    const handleLogin = async (event) => {
+        event.preventDefault();
+        try {            
+            const response = await login(userId, password);
+            console.log(response); 
+            
+            const {accessToken, refreshToken} = response.response;
+
+            if (accessToken && refreshToken) {
+                localStorage.setItem('access', accessToken);
+                localStorage.setItem('refresh', refreshToken);
+                // localStorage.setItem('nickname', nickname);
+                
+                console.log("로그인 완료");
+
+                const a = localStorage.getItem('access');
+                const b = localStorage.getItem('refresh');
+                console.log("access", a);
+                console.log("refresh", b);
+                
+                // 로그인 버전 화면으로 리렌더링하기
+            }            
+        } catch (error) {
+            console.error('로그인 오류:', error);
+        }
+    };
+
+    const navigateMyPage = () => {
+        navigate('/mypage');
+    }
 
     return (
-        <div>LandingPage
-            <button onClick={navigate('/mypage')}> 마이페이지 </button>
+        <div>
+            <h1> LandingPage </h1>
+            
+            <form onSubmit={handleLogin}>
+                <h2>로그인</h2>
+                <input 
+                    type="text" 
+                    placeholder="ID" 
+                    value={userId} 
+                    onChange={e => setUserId(e.target.value)}
+                />
+                <input 
+                    type="password" 
+                    placeholder="Password" 
+                    value={password} 
+                    onChange={e => setPassword(e.target.value)}
+                />
+                <button type="submit">로그인</button>
+            </form>
+
+
+            <h2> 마이페이지로 이동하기 </h2>
+            <button onClick={navigateMyPage}> 마이페이지 </button>
         </div>
     )
 }

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,15 +1,55 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import getMyPageInfo, { createWorkSpace } from '../api/myPageApi';
 
-// 렌더링 될 때 해당 유저의 spaceId 리스트, snapshot 리스트 요청 보내기
-// 방 목록 표시는 일단 버튼 뿌려주는 식으로 ㄱㄱ
 const MyPage = () => {
-  return (
-    <div>
-        <button>
+    const [spaceIds, setSpaceIds] = useState([]);
+    const [snapshotIds, setSnapshotIds] = useState([]);
+    const navigate = useNavigate();
 
-        </button>
-    </div>
-  )
-}
+    const accessToken = localStorage.getItem("access");     
 
-export default MyPage
+    useEffect(() => {
+        const fetchMyPageInfo = async () => {
+            try {
+                const response = await getMyPageInfo(accessToken);
+                console.log(response)
+                console.log("마이페이지 인포 받음");
+                // setSpaceIds(data.spaceIds);
+                // setSnapshotIds(data.snapshotIds);
+            } catch (error) {
+                console.error('마이페이지 정보 로드 실패:', error);
+            }
+        };
+        fetchMyPageInfo();
+    }, [accessToken]);
+
+    // 작업실 생성 함수
+    const handleCreateWorkSpace = async () => {
+        try {
+            const response = await createWorkSpace(accessToken);
+            console.log("작업실 생성 응답:", response);
+            // 일단은 작업실로 바로 가기
+            // 후에 방 생성 화면 뜨고, 방 제목과 설명 입력받고, 멤버 추가 기능 구현 필요
+        } catch (error) {
+            console.error("작업실 생성 오류:", error);
+        }
+
+    }
+
+    // spaceId를 순회하면서 id, index를 얻을 수 있다는 가정
+    // 
+    return (
+        <div>
+            <h1>MyPage</h1>
+            <button onClick={handleCreateWorkSpace}> 새 작업실 </button>
+            {/* {spaceIds.map((id, index) => (
+                <div key={id} onClick={() => navigate(`/workspace/${id}`)}>
+                    작업실 {index + 1}
+                </div>
+            ))} */}
+        </div>
+    );
+};
+
+export default MyPage;

--- a/frontend/src/pages/WorkPlacePage.js
+++ b/frontend/src/pages/WorkPlacePage.js
@@ -1,11 +1,17 @@
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import WorkSpaceContainer from "../containers/workplace/WorkSpaceContainer";
 import WebSocketContainer from "../containers/WebSocket/WebSocketContainer";
+import ChatContainer from "../containers/workplace/ChatContainer";
 
 const WorkPlacePage = () => {
+  const { spaceId } = useParams(); // 현재 spaceId 얻기
+
   return (
     <>
-      <WebSocketContainer />
+      <WebSocketContainer spaceId={spaceId} />
       <WorkSpaceContainer />
+      <ChatContainer spaceId={spaceId} />
     </>
   );
 };


### PR DESCRIPTION
# 서버측 api 구현 완료 후 테스트 필요

# 구현 사항
## 1. 로그인
- 랜딩페이지에 간단한 로그인 form 구현
- 로그인 api (테스트 완료)

## 2. 마이페이지
- 페이지 마운트 시, 해당 유저의 작업실 목록(spaceIds), 스냅샷 목록(snapshotIds) 요청하는 api 요청 (테스트 필요)
- 받아온 정보를 토대로 작업실 병렬적으로 표시 (각 작업실은 spaceId 를 갖고있음)
- 새 작업실 만들기 api 구현 완 (테스트 필요)

## 3. 작업실, 채팅기능 (전체 테스트 필요)
- 화면 오른쪽에 채팅창 포함
- WebSocketContainer에 채팅 소켓 통신 로직 포함 
- 작업실 마운트 시 이전 채팅 기록 요청해서 렌더링해주는 로직 구현 
- 채팅 send, 채팅 수신해서 전역 상태에 저장하기, 상태 반영해서 채팅창 업데이트 하기 구현 
- 채팅창 내가 보낸 메시지, 남이 보낸 메시지 표시 구현 

기타 필요한 slice 파일 등 업데이트 했습니다

