### PR TITLE
fix: 워크스페이스 로딩과 관련해 짜여져 있던 서비스단 쿼리문 수정

### DIFF
--- a/backend/letsnote/src/main/java/com/geeks/letsnote/domain/account/dao/AccountRepository.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/domain/account/dao/AccountRepository.java
@@ -24,4 +24,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Long findIdByUsername(String username);
 
+    @Query("SELECT w.nickname FROM Account w WHERE w.id IN :accountIds")
+    List<String> findMemberNickNamesFromAccountIds(@Param("accountIds")List<Long> accountIdsFromSpaceId);
 }

--- a/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/application/impl/WorkspaceImpl.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/application/impl/WorkspaceImpl.java
@@ -39,34 +39,19 @@ public class WorkspaceImpl implements WorkspaceService {
 
     @Override
     public List<ResponseWorkspaces.WorkspaceDto> getAllWorkspacesByOwnerId(Long accountId) {
-        List<WorkspaceMemberMap> workspaceMemberMaps = workspaceMemberMapRepository.findAllByAccountId(accountId);
-        List<Workspace> workspaceList = new ArrayList<>();
-        for(WorkspaceMemberMap workspaceMemberMap : workspaceMemberMaps){
-            Optional<Workspace> workspace = workspaceRepository.findById(workspaceMemberMap.getSpaceId());
-            workspaceList.add(workspace.get());
-        }
-
-        Collections.sort(workspaceList, Comparator.comparing(Workspace::getUpdateAt).reversed());
+        List<String> workSpaceIdsFromAccountId = workspaceMemberMapRepository.findSpaceIdsByAccountId(accountId);
+        List<Workspace> workspaceList = workspaceRepository.findSpaceIdsByOwnerIdsOrderByUpdateAt(workSpaceIdsFromAccountId);
         List<ResponseWorkspaces.WorkspaceDto> workspaceDtoList = new ArrayList<>();
 
         for(Workspace workspace : workspaceList) {
-            List<WorkspaceMemberMap> memberMaps = workspaceMemberMapRepository.findAllBySpaceId(workspace.getSpaceId());
-            List<Long> members = new ArrayList<>();
-            for(WorkspaceMemberMap workspaceMemberMap : memberMaps){
-                if(workspace.getOwnerId() != workspaceMemberMap.getAccountId()){
-                    members.add(workspaceMemberMap.getAccountId());
-                }
-            }
-            Optional<Account> workspaceOwner = accountRepository.findById(workspace.getOwnerId());
-            List<String> memberNicknames = new ArrayList<>();
-            for(Long memberId : members){
-                Optional<Account> member = accountRepository.findById(memberId);
-                memberNicknames.add(member.get().getNickname());
-            }
+            List<Long> accountIdsFromSpaceId = workspaceMemberMapRepository.findAccountIdsBySpaceId(workspace.getSpaceId());
+            List<String> memberNickNames = accountRepository.findMemberNickNamesFromAccountIds(accountIdsFromSpaceId);
+            String ownerNickName = accountRepository.findNicknameById(workspace.getOwnerId());
+
             ResponseWorkspaces.WorkspaceDto workspaceDto = ResponseWorkspaces.WorkspaceDto.builder()
                     .spaceId(workspace.getSpaceId())
-                    .ownerNickname(workspaceOwner.get().getNickname())
-                    .memberNicknames(memberNicknames)
+                    .ownerNickname(ownerNickName)
+                    .memberNicknames(memberNickNames)
                     .spaceTitle(workspace.getSpaceTitle())
                     .spaceContent(workspace.getSpaceContent())
                     .updateAt(workspace.getUpdateAt())

--- a/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/dao/WorkspaceMemberMapRepository.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/dao/WorkspaceMemberMapRepository.java
@@ -2,11 +2,19 @@ package com.geeks.letsnote.domain.studio.workSpace.dao;
 
 import com.geeks.letsnote.domain.studio.workSpace.entity.WorkspaceMemberMap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WorkspaceMemberMapRepository extends JpaRepository<WorkspaceMemberMap,Long> {
-    List<WorkspaceMemberMap> findAllBySpaceId(String spaceId);
 
-    List<WorkspaceMemberMap> findAllByAccountId(Long accountId);
+    @Query("SELECT w.spaceId FROM WorkspaceMemberMap w WHERE w.accountId = :accountId")
+    List<String> findSpaceIdsByAccountId(@Param("accountId")Long accountId);
+
+//    @Query("SELECT w.accountId FROM WorkspaceMemberMap w WHERE w.spaceId = :spaceId AND w.accountId != :ownerId")
+//    List<Long> findAccountIdsBySpaceIdNotInOwnerId(@Param("spaceId")String spaceId, @Param("ownerId")Long ownerId);
+
+    @Query("SELECT w.accountId FROM WorkspaceMemberMap w WHERE w.spaceId = :spaceId")
+    List<Long> findAccountIdsBySpaceId(@Param("spaceId")String spaceId);
 }

--- a/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/dao/WorkspaceRepository.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/dao/WorkspaceRepository.java
@@ -2,6 +2,8 @@ package com.geeks.letsnote.domain.studio.workSpace.dao;
 
 import com.geeks.letsnote.domain.studio.workSpace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,7 @@ import java.util.List;
 @Repository
 public interface WorkspaceRepository extends JpaRepository<Workspace,String> {
     List<Workspace> findAllByOwnerId(Long ownerId);
+
+    @Query("SELECT w.spaceId FROM Workspace w WHERE w.ownerId IN :accountIds ORDER BY w.updateAt")
+    List<Workspace> findSpaceIdsByOwnerIdsOrderByUpdateAt(@Param("accountIds")List<String> accountIds);
 }


### PR DESCRIPTION
# #58
## 워크스페이스 로딩시 짜여져 있던 서비스단 쿼리문을 수정한다.

- 기존 워크스페이스 불러오는데 걸리는 시간 평균적으로 7초 정도 걸림
- 반복문으로 row 하나씩 셀렉하도록 짜여져 있던 코드 일괄적으로 수정, 비효율적인 코드 대거 제거함

findSpaceIdsByAccountId(accountId) => 
findSpaceIdsByOwnerIdsOrderByUpdateAt(workSpaceIdsFromAccountId) => 
for(workspaceList){
findAccountIdsBySpaceId(spaceId)
findMemberNickNamesFromAccountIds(accountIdsFromSpaceId)
findNicknameById(ownerId)
dtoList.add
}
return dtoList