### PR TITLE
fix: 작업실, 스냅샷 url에 파라미터 삽입시 무한로딩에 빠지는 문제 해결

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,10 +14,10 @@ const App = () => {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/mypage" element={<MyPage />} />
-          <Route path="/workspace/:spaceId" element={<WorkPlacePage />} />
-          <Route path="/snapshot/:snapshotId" element={<SnapshotPage />} /> 
           <Route path="/workspace" element={<WorkPlacePage />} />
           <Route path="/snapshot" element={<SnapshotPage />} />
+          <Route path="/workspace/:spaceId" element={<WorkPlacePage />} />
+          <Route path="/snapshot/:snapshotId" element={<SnapshotPage />} /> 
         </Routes>
       </Provider>
     </>

--- a/frontend/src/containers/WebSocket/WebSocketContainer.jsx
+++ b/frontend/src/containers/WebSocket/WebSocketContainer.jsx
@@ -40,7 +40,7 @@ export const sendCoordinate = (instrument, x, y) => {
       instrument: instrument,
       x: x,
       y: y,
-      spaceId: "2d92f8cb4ff848308a2a953e5b9b3966",      
+      spaceId: spaceId,      
     }),
   });
 };
@@ -53,7 +53,7 @@ export const sendMessage = (message, accountId, spaceId) => {
     body: JSON.stringify({
       msgContent: message,
       accountId: accountId,      
-      spaceId: "2d92f8cb4ff848308a2a953e5b9b3966",
+      spaceId: spaceId,
     }),
   });
 };

--- a/frontend/src/synth/Synth.js
+++ b/frontend/src/synth/Synth.js
@@ -6,8 +6,8 @@ const getTransport = () => {
 };
 
 const drumSamples = {
-  36: "audio/drum/36.mp3",
-  38: "audio/drum/38.mp3",
+  36: "/audio/drum/36.mp3",
+  38: "/audio/drum/38.mp3",
 };
 
 class Synth {
@@ -20,12 +20,14 @@ class Synth {
     this.activeInstrument = this.instruments[0];
     this.samplers = {};
 
+
     this.instruments.forEach((instrument) => {
       if (instrument !== "drum") {
         this.samplers[instrument] = new Tone.Sampler(
           scale,
           callback,
-          samples + instrument + "/"
+          // samples + instrument + "/"
+          "/audio/" + instrument + "/"
         );
       } else {
         this.samplers[instrument] = new Tone.Sampler(drumSamples);
@@ -71,7 +73,7 @@ class Synth {
     const activeSampler = this.samplers[Instrument];
     activeSampler.triggerAttackRelease(note, timing, time);
   }
-  
+
   setBPM(bpm = 120) {
     getTransport().bpm.value = bpm;
   }


### PR DESCRIPTION
# 구현사항

## 문제상황
url에 파라미터가 포함될 경우 로딩에서 벗어나지 못하는 문제를 해결했습니다.
이 문제가 해결돼야 작업실 방 분리, 스냅샷 조회가 가능했기에 높은 우선순위로 작업했습니다.

## 원인
디버거로도 문제가 뚜렷이 파악되지 않아, 개발자도구에서 각 소스를 불러오는 경로를 확인해보았습니다. 
각 악기에 대한 sampler 객체 생성 시, 파라미터가 포함되는 경우 오디오 파일에 대한 경로가 바뀌어서 발생한 문제였습니다.

정상 경로 예시: http://localhost:3000/audio/piano/D2.mp3
문제 경로 예시: http://localhost:3000/workspace/audio/piano/D2.mp3

## 해결 방법
synth.js 내에서 audio 파일을 찾아가는 경로를 절대경로로 바꿔주었습니다.
