### PR TITLE
feat: 스냅샷 렌더링 1차 구현

### DIFF
--- a/frontend/src/api/axiosInstance.js
+++ b/frontend/src/api/axiosInstance.js
@@ -7,7 +7,7 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   config => {    
-    const accessToken = localStorage.getItem('access');
+    const accessToken = sessionStorage.getItem('access');
     if (accessToken) {      
       config.headers.Authorization = `Bearer ${accessToken}`;
     }

--- a/frontend/src/api/myPageApi.js
+++ b/frontend/src/api/myPageApi.js
@@ -1,6 +1,6 @@
 import axiosInstance from './axiosInstance';
 
-const accountId = localStorage.getItem('accountId');
+const accountId = sessionStorage.getItem('accountId');
 
 const getMyPageInfo = async () => {
   try {    

--- a/frontend/src/api/nicknameApi.js
+++ b/frontend/src/api/nicknameApi.js
@@ -1,6 +1,6 @@
 import axiosInstance from './axiosInstance';
 
-const accountId = localStorage.getItem('accountId');
+const accountId = sessionStorage.getItem('accountId');
 
 const getMyNickname = async () => {
     try {    

--- a/frontend/src/api/snapshotApi.js
+++ b/frontend/src/api/snapshotApi.js
@@ -3,7 +3,7 @@ import axiosInstance from './axiosInstance';
 const getSnapshotInfo = async (snapshotId) => {
     try {        
         const response = await axiosInstance.get(`/feeds/snapshot-id?v=${snapshotId}`);        
-        console.log("getSnapshotInfo", response);
+        console.log("getSnapshotInfo -", snapshotId, ":", response.data);
         return response.data; 
     } catch (error) {
         console.error('getSnapshotInfo 에러:', error);   

--- a/frontend/src/app/slices/innerContentSlice.js
+++ b/frontend/src/app/slices/innerContentSlice.js
@@ -8,7 +8,8 @@ export const innerContentSlice = createSlice({
       x: null,
       y: null,
     },
-    notes: []
+    notes: [],
+    snapshotNotesList: [],
   },
   reducers: {
     setInnerContent: (state, action) => {
@@ -23,17 +24,34 @@ export const innerContentSlice = createSlice({
         instrumentGroup.notes.forEach((note) => {
           state.notes.push({
             x: note.noteX,
-            y: note.noteY,  
+            y: note.noteY,
             instrument: instrumentGroup.instrument.toLowerCase()
-          });          
+          });
         });
       });
-      
-    }
+    },
+
+    setSnapshotNotesList: (state, action) => {
+      state.snapshotNotesList = [];
+      action.payload.forEach((instrumentGroup) => {
+        console.log("리덕스:", instrumentGroup);
+        console.log("snapshotNotesList:", state.snapshotNotesList);
+        if (instrumentGroup.notes) {
+          instrumentGroup.notes.forEach((note) => {
+            state.snapshotNotesList.push({
+              x: note.noteX,
+              y: note.noteY,
+              instrument: instrumentGroup.instrument.toLowerCase()
+            });
+          });
+        }        
+      });
+    },
+
   },
 });
 
-export const { setInnerContent, setNotesList } = innerContentSlice.actions;
+export const { setInnerContent, setNotesList, setSnapshotNotesList } = innerContentSlice.actions;
 
 export const selectInnerContent = (state) => state.sample.innerContent;
 export const selectNotes = (state) => state.innerContent.notes;

--- a/frontend/src/components/BeatColumn/BeatBox.js
+++ b/frontend/src/components/BeatColumn/BeatBox.js
@@ -7,13 +7,13 @@ const Container = styled.div`
   margin: 0.5px;
   background-color: ${(props) =>
     props.active &&
-    props.visualizeInstrument[
+      props.visualizeInstrument[
       props.instrumentList.indexOf(props.instrument)
-    ] === true
+      ] === true
       ? pickActiveColor(props.instrument)
       : props.col % 8 < 4
-      ? "lightgray"
-      : props.inactiveColor};
+        ? "lightgray"
+        : props.inactiveColor};
   width: 2rem;
 
   margin-bottom: ${(props) => (props.row % 8 === 5 ? 2 : 0.5)}px;
@@ -51,18 +51,64 @@ const BeatBox = ({
 
   const innerContent = useSelector((state) => state.innerContent.innerContent);
   const notes = useSelector((state) => state.innerContent.notes);
+  const snapshotNotes = useSelector((state) => state.innerContent.snapshotNotesList);
+  const stateInner = useSelector((state) => state.innerContent);
+
+  // const notes = useSelector(state => 
+  //   isSnapshot ? state.innerContent.snapshotNotesList : state.innerContent.notesList
+  // );
+
+  // useEffect(() => {
+  //   // notes 배열을 검사하여 현재 BeatBox 위치에 해당하는 노트가 있는지 확인
+  //   // console.log("instrumentData:", instrumentData.snapshotNotesList);    
+  //   console.log("BeatBox - snapshotNotes:", stateInner);  
+
+  //   if (isSnapshot){
+  //     const activeNote = snapshotNotes.find((n) => n.x === col && n.y === row);
+  //     if (activeNote && !active) {
+  //       // 해당하는 노트가 있으면, isActive 상태를 true로 설정
+  //       setActive(true);
+  //       setInstrument(activeNote.instrument);
+  //       setActiveBoxes(row, true);
+  //       setActiveInstrument(row, activeNote.instrument);
+  //     }
+  //   } else {
+  //     const activeNote = notes.find((n) => n.x === col && n.y === row);
+  //     if (activeNote && !active) {
+  //       // 해당하는 노트가 있으면, isActive 상태를 true로 설정
+  //       setActive(true);
+  //       setInstrument(activeNote.instrument);
+  //       setActiveBoxes(row, true);
+  //       setActiveInstrument(row, activeNote.instrument);
+  //     }
+  //   }
+  // }, [notes, col, row, setActiveBoxes, setActiveInstrument]);
 
   useEffect(() => {
-    // notes 배열을 검사하여 현재 BeatBox 위치에 해당하는 노트가 있는지 확인
-    const activeNote = notes.find((n) => n.x === col && n.y === row);
+    let activeNote;
+
+    // 스냅샷 모드인 경우
+    if (isSnapshot) {
+      // 스냅샷 노트 리스트에서 현재 위치에 해당하는 노트 찾기
+      activeNote = snapshotNotes.find((n) => n.x === col && n.y === row);
+      console.log("snapshot의 activeNote:", activeNote);
+    } else {
+      // 워크스페이스 모드인 경우
+      activeNote = notes.find((n) => n.x === col && n.y === row);
+      console.log("workspace의 activeNote:", activeNote);
+    }
+
+    // 해당하는 노트가 있으면 상태 업데이트
     if (activeNote && !active) {
-      // 해당하는 노트가 있으면, isActive 상태를 true로 설정
       setActive(true);
       setInstrument(activeNote.instrument);
       setActiveBoxes(row, true);
       setActiveInstrument(row, activeNote.instrument);
     }
-  }, [notes, col, row, setActiveBoxes, setActiveInstrument]);
+  }, [snapshotNotes, notes, col, row, active, isSnapshot, setActiveBoxes, setActiveInstrument]);
+
+
+
 
   const instrumentList = ["piano", "guitar", "drum"];
 

--- a/frontend/src/components/BeatColumn/BeatColumn.js
+++ b/frontend/src/components/BeatColumn/BeatColumn.js
@@ -171,6 +171,7 @@ class BeatColumn extends Component {
           visualizeInstrument={visualizeInstrument}
           col={id}
           row={i}
+          isSnapshot={this.props.isSnapshot}
         />
       );
     }

--- a/frontend/src/components/BeatColumn/DrumBox.js
+++ b/frontend/src/components/BeatColumn/DrumBox.js
@@ -62,25 +62,48 @@ const DrumBox = ({
   visualizeInstrument,
   col,
   row,
+  isSnapshot,
 }) => {
   const [active, setActive] = useState(propActive);
   const innerContent = useSelector((state) => state.innerContent.innerContent);
   const instrumentList = ["piano", "guitar", "drum"];
   const notes = useSelector((state) => state.innerContent.notes);
+  const snapshotNotes = useSelector((state) => state.innerContent.snapshotNotesList);
+
+  // useEffect(() => {
+  //   // notes 배열을 검사하여 현재 BeatBox 위치에 해당하는 노트가 있는지 확인
+  //   const activeNote = notes.find((n) => n.x === col && n.y === row);
+  //   if (activeNote && !active) {
+  //     console.log(
+  //       `activeNote: x:${activeNote.x} y:${activeNote.y} inst:${activeNote.instrument}`
+  //     );
+  //     // 해당하는 노트가 있으면, isActive 상태를 true로 설정
+  //     setActive(true);
+  //     setActiveBoxes(row, true);
+  //     setActiveInstrument(row, activeNote.instrument);
+  //   }
+  // }, [notes, col, row, setActiveBoxes, setActiveInstrument]);
 
   useEffect(() => {
-    // notes 배열을 검사하여 현재 BeatBox 위치에 해당하는 노트가 있는지 확인
-    const activeNote = notes.find((n) => n.x === col && n.y === row);
+    let activeNote;
+    
+    if (isSnapshot) {
+      // 스냅샷 모드에서 스냅샷 노트 리스트를 사용
+      activeNote = snapshotNotes.find((n) => n.x === col && n.y === row);
+      console.log("스냅샷 드럼:", activeNote);
+    } else {
+      // 기존 모드에서 일반 노트 리스트를 사용
+      activeNote = notes.find((n) => n.x === col && n.y === row);
+      console.log("작업실 드럼:", activeNote);
+    }
+  
     if (activeNote && !active) {
-      console.log(
-        `activeNote: x:${activeNote.x} y:${activeNote.y} inst:${activeNote.instrument}`
-      );
-      // 해당하는 노트가 있으면, isActive 상태를 true로 설정
+      // 해당하는 노트가 있으면 상태 업데이트
       setActive(true);
       setActiveBoxes(row, true);
       setActiveInstrument(row, activeNote.instrument);
     }
-  }, [notes, col, row, setActiveBoxes, setActiveInstrument]);
+  }, [snapshotNotes, notes, col, row, active, isSnapshot, setActiveBoxes, setActiveInstrument]);
 
   useEffect(() => {
     if (

--- a/frontend/src/containers/WebSocket/WebSocketContainer.jsx
+++ b/frontend/src/containers/WebSocket/WebSocketContainer.jsx
@@ -5,8 +5,8 @@ import * as SockJS from "sockjs-client";
 import { setInnerContent } from "../../app/slices/innerContentSlice";
 import { addMessage } from "../../app/slices/chatSlice";
 
-const accessToken = localStorage.getItem("access");
-const accountId = localStorage.getItem("accountId");
+const accessToken = sessionStorage.getItem("access");
+const accountId = sessionStorage.getItem("accountId");
 const space_id = localStorage.getItem("spaceId");
 
 export const stompClient = new StompJS.Client({

--- a/frontend/src/containers/workplace/ChatContainer.jsx
+++ b/frontend/src/containers/workplace/ChatContainer.jsx
@@ -88,7 +88,7 @@ const ChatContainer = ({ spaceId, memberList, nickname }) => {
     const chatMessages = useSelector(state => state.chat.spaces[spaceId]) // 해당 채팅방 메시지 가져오기
     const [isVisible, setIsVisible] = useState(false);    
 
-    const accountId = localStorage.getItem("accountId");
+    const accountId = sessionStorage.getItem("accountId");
 
     // 채팅 목록 업데이트 관련 로직
     useEffect(() => {        

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -85,8 +85,8 @@ const MyPage = () => {
     }
   };
 
-  const accessToken = localStorage.getItem("access");
-  const accountId = localStorage.getItem("accountId");
+  const accessToken = sessionStorage.getItem("access");
+  const accountId = sessionStorage.getItem("accountId");
 
   useEffect(() => {
     const fetchMyPageInfo = async () => {

--- a/frontend/src/pages/SnapshotPage.js
+++ b/frontend/src/pages/SnapshotPage.js
@@ -6,7 +6,7 @@ import WorkSpaceContainer from '../containers/workplace/WorkSpaceContainer';
 import SaveSnapshotModal from '../components/WorkSpace/SaveSnapshotModal';
 import styled from 'styled-components';
 import { getSnapshotInfo } from '../api/snapshotApi';
-import { setNotesList } from '../app/slices/innerContentSlice';
+import { setSnapshotNotesList } from '../app/slices/innerContentSlice';
 
 const Container = styled.div`
   height: 100vh;
@@ -20,24 +20,43 @@ const SnapshotPage = () => {
     const [isReleaseModalOpen, setIsReleaseModalOpen] = useState(false);    
 
     // 작업실 입장 시 데이터 요청
+    // useEffect(() => {
+    //   const fetchSnapshotInfo = async () => {
+    //     try {
+    //       const response = await getSnapshotInfo(snapshotId);    
+          
+    //       console.log("스냅샷 정보 response", response);
+    //       console.log("스냅샷 정보 - 뭘 넣고 있는거냐:", response.response);
+          
+    //       // notesList 전체를 Redux store에 저장
+    //       dispatch(setSnapshotNotesList(response.response));
+          
+    //       console.log("스냅샷 입장 - snapshotInfo:", response.response);
+    //     } catch (error) {
+    //       console.error('Error fetching snapshot info:', error);
+    //     }
+    //   };
+    
+    //   fetchSnapshotInfo();
+    // }, [snapshotId, dispatch]);
+
     useEffect(() => {
       const fetchSnapshotInfo = async () => {
         try {
+          console.log("스냅샷 요청한 snapshotId", snapshotId);
           const response = await getSnapshotInfo(snapshotId);    
-          
-          console.log("스냅샷 정보 response", response);
-          
-          // notesList 전체를 Redux store에 저장
-          dispatch(setNotesList(response.response.notesList));
-          
-          console.log("스냅샷 입장 - snapshotInfo:", response.response);
+          // API 응답에서 스냅샷 노트 정보를 추출하여 dispatch
+          if (response && response.response) {
+            dispatch(setSnapshotNotesList(response.response));
+          }
         } catch (error) {
           console.error('Error fetching snapshot info:', error);
         }
       };
     
       fetchSnapshotInfo();
-    }, [snapshotId, dispatch]);
+    }, [dispatch, snapshotId]);
+    
 
 
     const handleModalOpen = () => {

--- a/frontend/src/pages/WorkPlacePage.js
+++ b/frontend/src/pages/WorkPlacePage.js
@@ -19,7 +19,7 @@ const Container = styled.div`
 `;
 
 const spaceId = localStorage.getItem("spaceId");
-const accountId = localStorage.getItem("accountId");
+const accountId = sessionStorage.getItem("accountId");
 
 const WorkPlacePage = () => {
   const dispatch = useDispatch();
@@ -49,7 +49,7 @@ const WorkPlacePage = () => {
         // notesList 전체를 Redux store에 저장
         dispatch(setNotesList(response.response.notesList));
 
-        console.log("작업실 입장 - workspaceInfo:", response.response);
+        console.log("작업실 입장 - workspaceInfo:", response.response.notesList);
       } catch (error) {
         console.error("Error fetching workspace info:", error);
       }


### PR DESCRIPTION
# 구현사항

- 스냅샷 불러올 때도 작업실에서 노트 정보 불러오는 것과 마찬가지 로직이 적용될 거라 생각하고 테스트를 미뤘는데, 전혀 적용이 안되는 문제를 발견
- 스냅샷 용으로 따로 전역상태 빼서 관리하고, BeatBox와 DrumBox에서 가져다 쓰는 식으로 수정했습니다. 
- 현재 어떤 스냅샷 id로 들어가도 API 응답 결과가 똑같은 현상(피아노만 154개, 드럼 박스 위치에 4개 찍혀있음)이 있는데, 이 부분 확인 좀 부탁드려요
- 로그인 후 회원정보 sessionStorage로 저장 장소 바뀌었는데, 불러오는 API들에서는 여전히 localStorage에서 불러오고 있어 이 부분 수정했습니다. 
