### PR TITLE
feat: 피드에서 스냅샷 열람 후 뒤로가기 시 마이페이지로 가는 문제 수정

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,8 +17,6 @@ const App = () => {
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/workspace/:spaceId" element={<WorkPlacePage />} />
           <Route path="/snapshot/:snapshotId" element={<SnapshotPage />} /> 
-          <Route path="/workspace" element={<WorkPlacePage />} />
-          <Route path="/snapshot" element={<SnapshotPage />} />
         </Routes>
         <VOC/>
       </Provider>

--- a/frontend/src/containers/Snapshot/SnapshotHeader.jsx
+++ b/frontend/src/containers/Snapshot/SnapshotHeader.jsx
@@ -61,13 +61,19 @@ const Message = styled.div`
 `;
 
 
-const SnapshotHeader = ({ onOpenModal }) => {
+const SnapshotHeader = ({ onOpenModal, fromMyPage }) => {
   const navigate = useNavigate();
   const [showMessage, setShowMessage] = useState(false);
-  const [displayMessage, setDisplayMessage] = useState(false);
-
+  const [displayMessage, setDisplayMessage] = useState(false);  
+  
   const handleGoBack = () => {
-    navigate('/mypage');
+    if (fromMyPage){
+      console.log(`뒤로가기 - fromMyPage: ${fromMyPage}`);
+      navigate('/mypage');
+    } else {
+      console.log(`뒤로가기 - fromMyPage: ${fromMyPage}`);
+      navigate('/');
+    }
   }  
 
   const handleShare = () => {

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -106,7 +106,7 @@ const LandingPage = () => {
               showConfirmButton: false,
               timer: 1500
             });
-            
+
           }
         }
         closeRegisterModal();
@@ -142,10 +142,8 @@ const LandingPage = () => {
   };
 
   const handleLogout = () => {
-    // Clear session storage on logout
     sessionStorage.removeItem("access");
     sessionStorage.removeItem("refresh");
-    // sessionStorage.removeItem("nickname");
     sessionStorage.removeItem("accountId");
     setIsLoggedIn(false);
     navigate("/");
@@ -181,7 +179,10 @@ const LandingPage = () => {
           newPostCardList.push(
             <div
               key={postList[i].snapshotId}
-              onClick={() => navigate(`/snapshot/${postList[i].snapshotId}`)}
+              onClick={() =>
+                navigate(`/snapshot/${postList[i].snapshotId}`,
+                  { state: { fromMyPage: false } }
+                )}
             >
               <PostCard
                 snapshotTitle={postList[i].snapshotTitle}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -96,7 +96,7 @@ const MyPage = () => {
         console.log("작업실 생성 완료 - response:", response);
         localStorage.setItem("spaceId", response.response.spaceId);
         localStorage.setItem("title", title);
-        navigate(`/workspace/${response.response.spaceId}`);        
+        navigate(`/workspace/${response.response.spaceId}`);
       } else {
         console.log("작업실 생성 실패");
       }
@@ -222,7 +222,10 @@ const MyPage = () => {
           {snapshots.map((snapshot) => (
             <div
               key={snapshot.snapshotId}
-              onClick={() => navigate(`/snapshot/${snapshot.snapshotId}`)}
+              onClick={() =>
+                navigate(`/snapshot/${snapshot.snapshotId}`,
+                  { state: { fromMyPage: true } }
+                )}
             >
               <PostCard
                 snapshotTitle={snapshot.snapshotTitle}

--- a/frontend/src/pages/SnapshotPage.js
+++ b/frontend/src/pages/SnapshotPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import SnapshotHeader from "../containers/Snapshot/SnapshotHeader";
 import WorkSpaceContainer from "../containers/workplace/WorkSpaceContainer";
 import SaveSnapshotModal from "../components/WorkSpace/SaveSnapshotModal";
@@ -18,32 +18,22 @@ const Container = styled.div`
 
 const SnapshotPage = () => {
   const dispatch = useDispatch();
+  const location = useLocation();
 
   const { snapshotId } = useParams();
-  const [isReleaseModalOpen, setIsReleaseModalOpen] = useState(false);
-
-  // 작업실 입장 시 데이터 요청
-  // useEffect(() => {
-  //   const fetchSnapshotInfo = async () => {
-  //     try {
-  //       const response = await getSnapshotInfo(snapshotId);
-
-  //       console.log("스냅샷 정보 response", response);
-  //       console.log("스냅샷 정보 - 뭘 넣고 있는거냐:", response.response);
-
-  //       // notesList 전체를 Redux store에 저장
-  //       dispatch(setSnapshotNotesList(response.response));
-
-  //       console.log("스냅샷 입장 - snapshotInfo:", response.response);
-  //     } catch (error) {
-  //       console.error('Error fetching snapshot info:', error);
-  //     }
-  //   };
-
-  //   fetchSnapshotInfo();
-  // }, [snapshotId, dispatch]);
-
+  const [isReleaseModalOpen, setIsReleaseModalOpen] = useState(false);  
+  const [isFromMyPage, setIsFromMyPage] = useState(false);
+  
   useEffect(() => {
+    const fromMyPage = location.state?.fromMyPage;  
+    setIsFromMyPage(fromMyPage);
+    
+    if (fromMyPage){
+      console.log(`마이페이지로부터 입장 - fromMyPage: ${fromMyPage}`)
+    } else {
+      console.log(`피드 입장 | 새로고침 | 스냅샷 생성 후 보러가기 - fromMyPage: ${fromMyPage}`)      
+    }
+
     const fetchSnapshotInfo = async () => {
       try {
         // console.log("스냅샷 요청한 snapshotId", snapshotId);
@@ -83,7 +73,7 @@ const SnapshotPage = () => {
 
   return (
     <Container>
-      <SnapshotHeader onOpenModal={handleModalOpen} />
+      <SnapshotHeader onOpenModal={handleModalOpen} fromMyPage={isFromMyPage} />
       {isReleaseModalOpen && (
         <SaveSnapshotModal
           onClose={handleModalClose}


### PR DESCRIPTION
# 구현 사항

1. 마이페이지에서 스냅샷 진입시 뒤로가기 버튼 누르면 마이페이지로 돌아갑니다
2. 그 외 상황에서는 모두 피드로 돌아갑니다.

- 피드에서 스냅샷 진입시 뒤로가기 버튼 누르면 피드로 돌아갑니다
- 스냅샷 생성 후 바로 '보러가기' 눌러서 진입시 뒤로가기 버튼 누르면 피드로 돌아갑니다
- 마이페이지에서 진입했어도, 새로고침했다면 피드로 돌아갑니다