### PR TITLE
Front/fix/beat progress bar fix

### DIFF
--- a/frontend/src/components/BeatControls/BeatControls.js
+++ b/frontend/src/components/BeatControls/BeatControls.js
@@ -48,7 +48,6 @@ const BeatControls = ({
   changeInstrument,
   columns,
   count,
-  handleCountChange,
   handleIsPlaying,
   isPlaying,
 }) => {
@@ -66,7 +65,6 @@ const BeatControls = ({
           <BeatProgressBar
               columns={columns}
               count={count}
-              handleCountChange={handleCountChange}
           />
         </CenterSection>
         <RightSection>

--- a/frontend/src/components/BeatControls/BeatProgressBar.js
+++ b/frontend/src/components/BeatControls/BeatProgressBar.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import tw from "tailwind-styled-components";
+import { handleCountChange } from "../BeatGrid/BeatGrid";
 
 const ProgressBarContainer = tw.div`
     flex
@@ -7,7 +8,7 @@ const ProgressBarContainer = tw.div`
     w-full dark:bg-gray-700
 `;
 
-const BeatProgressBar = ({ count, handleCountChange, columns }) => {
+const BeatProgressBar = ({ count, columns }) => {
   const [isDragging, setIsDragging] = useState(false);
 
   const handleMouseDown = () => {

--- a/frontend/src/components/BeatGrid/BeatGrid.js
+++ b/frontend/src/components/BeatGrid/BeatGrid.js
@@ -76,14 +76,20 @@ export const resetCount = () => {
   count = -1;
 };
 
+export const getCount = () => {
+  return count;
+}
+
+export const handleCountChange = (newCount) => {
+  count = newCount;
+}
+
+
 class BeatGrid extends React.PureComponent {
   constructor(props) {
     super(props);
     console.log("rerender");
     this.cols = [];
-    // this.state = {
-    //   count: -1,
-    // }
   }
 
 
@@ -105,8 +111,8 @@ class BeatGrid extends React.PureComponent {
   };
 
   trigger = (time) => {
-    // this.addCount();
     count += 1;
+    this.props.setCount(count);
     this.playBeat(time);
   };
 

--- a/frontend/src/components/BeatGrid/BeatGrid.js
+++ b/frontend/src/components/BeatGrid/BeatGrid.js
@@ -102,6 +102,7 @@ class BeatGrid extends React.PureComponent {
   playBeat = (time) => {
     const { columns } = this.props;
     const activeBeat = count % columns;
+    this.props.setCount(activeBeat);
     console.log(count);
     console.log("activeBeat : ",activeBeat);
     
@@ -112,7 +113,6 @@ class BeatGrid extends React.PureComponent {
 
   trigger = (time) => {
     count += 1;
-    this.props.setCount(count);
     this.playBeat(time);
   };
 

--- a/frontend/src/containers/workplace/WorkSpaceContainer.js
+++ b/frontend/src/containers/workplace/WorkSpaceContainer.js
@@ -1,7 +1,7 @@
 import React, { Component, createRef } from "react";
 import styled from "styled-components";
 import tw from "tailwind-styled-components";
-import BeatGrid from "../../components/BeatGrid/BeatGrid";
+import BeatGrid, { getCount } from "../../components/BeatGrid/BeatGrid";
 import Synth from "../../synth/Synth";
 import Loading from "../../components/Loading";
 import { availableNotes, availableDrumNotes } from "../../constants/scale";
@@ -79,6 +79,7 @@ class WorkSpaceContainer extends Component {
       columns: 100,
       availableNotes,
       availableDrumNotes,
+      count : -1,
       synth: null,
       visualizeInstrument: [true, true, true],
       isPlaying: false,
@@ -110,14 +111,16 @@ class WorkSpaceContainer extends Component {
     this.state.synth.repeat(BeatGrid.trigger, "8n");
   };
 
-  handleCountChange = (newCount) => {
-    this.setState({ count: newCount });
-  };
-
   handleIsPlaying = () => {
     this.setState((prevState) => ({
       isPlaying: !prevState.isPlaying,
     }));
+  };
+
+  setCount = (newCount) => {
+    this.setState({
+      count: newCount,
+    });
   };
 
   play = async () => {
@@ -232,6 +235,7 @@ class WorkSpaceContainer extends Component {
     this.stop();
   }
 
+
   render() {
     const {
       loading,
@@ -240,8 +244,8 @@ class WorkSpaceContainer extends Component {
       availableNotes,
       availableDrumNotes,
       visualizeInstrument,
-      count,
       isPlaying,
+      count,
     } = this.state;
 
     if (loading) {
@@ -271,7 +275,7 @@ class WorkSpaceContainer extends Component {
                 isSnapshot={this.props.isSnapshot}
                 spaceId={this.props.spaceId}
                 sendCoordinate={this.props.sendCoordinate}
-                count={count}
+                setCount={this.setCount}
                 sendLoop={this.props.sendLoop}
                 changeColumns={this.changeColumns}
                 sendMousePosition={this.props.sendMousePosition}
@@ -291,7 +295,6 @@ class WorkSpaceContainer extends Component {
             changeInstrument={this.changeInstrument}
             columns={columns}
             count={count}
-            handleCountChange={this.handleCountChange}
             handleIsPlaying={this.handleIsPlaying}
             isPlaying={isPlaying}
           />


### PR DESCRIPTION
## 버그 해결

1. BeatGrid가 WorkspaceContainer의 상태인 count를 빌려쓰는 상황에서, BeatGrid쪽에 전역으로 가지고 있는걸로 변경하고, BeatProgressBar에 count를 전달해서 매번 바꿔줘야 하는 상황때문에 WorkspaceCotainer가 BeatGrid의 전역 count를 갱신받아 상태를 수정하는 것으로 변경.
2. 재생 바 한바퀴 돌면 초기화되도록 수정