### PR TITLE
Back/chore/hashmap fix 2

### DIFF
--- a/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/EditorSocketController.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/EditorSocketController.java
@@ -203,4 +203,9 @@ public class EditorSocketController {
 				accountConnectedSessions.remove(spaceId);
 		}
 	}
+
+	public void deleteUserInAccountConnectedSessions (Map.Entry<String, String> entry, String spaceId){
+		System.out.println("삭제 완료 : "+entry.getValue());
+		accountConnectedSessions.get(spaceId).remove(entry.getKey());
+	}
 }

--- a/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/WebRTCController.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/WebRTCController.java
@@ -85,8 +85,7 @@ public class WebRTCController {
                 simpMessagingTemplate.convertAndSendToUser(entry.getKey(), "/topic/webrtc/" + spaceId + "/exit/public", new WebRTCResponse.ExitUser(senderId));
             }
             else{
-                editorSocketController.accountConnectedSessions.get(spaceId).remove(entry.getKey());
-                System.out.println("삭제 완료 : "+entry.getValue());
+                editorSocketController.deleteUserInAccountConnectedSessions(entry, spaceId);
             }
         }
     }

--- a/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/WebRTCController.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/global/network/api/WebRTCController.java
@@ -79,12 +79,13 @@ public class WebRTCController {
     public void sendUserExit(@Valid @Payload WebRTCRequest.ExitUser user, @DestinationVariable String spaceId, SimpMessageHeaderAccessor headerAccessor) throws Exception {
         String senderSession = headerAccessor.getUser().getName();
         String senderId = editorSocketController.accountConnectedSessions.get(spaceId).get(senderSession);
-        System.out.println("senderId == "+ senderId);
+        System.out.println("senderId == "+ senderId +" "+ user.userId());
         for(Map.Entry<String, String> entry : editorSocketController.accountConnectedSessions.get(spaceId).entrySet()) {
-            if (!entry.getValue().equals(user.userId())) {
+            if (!entry.getValue().equals(senderId)) {
                 simpMessagingTemplate.convertAndSendToUser(entry.getKey(), "/topic/webrtc/" + spaceId + "/exit/public", new WebRTCResponse.ExitUser(senderId));
             }
             else{
+                System.out.println("삭제 시도 : "+entry.getValue());
                 editorSocketController.deleteUserInAccountConnectedSessions(entry, spaceId);
             }
         }

--- a/frontend/src/containers/WebSocket/WebSocketContainer.jsx
+++ b/frontend/src/containers/WebSocket/WebSocketContainer.jsx
@@ -9,7 +9,7 @@ import {
 import { addMessage } from "../../app/slices/chatSlice";
 import { updateCursorPosition } from "../../app/slices/cursorSlice";
 
-const WebSocketContainer = ({ spaceId, children }) => {
+const WebSocketContainer = ({ spaceId, mySocketId, children }) => {
   const dispatch = useDispatch();
   const [stompClient, setStompClient] = useState(null);
   const [isConnected, setIsConnected] = useState(false);
@@ -55,7 +55,7 @@ const WebSocketContainer = ({ spaceId, children }) => {
             client.publish({
                 destination: `/app/webrtc/${spaceId}/exit/sendExit`,
                 body: JSON.stringify({
-                  userId: accountId,
+                  userId: mySocketId,
                 }),
             });
             console.log("전송 완료", client);

--- a/frontend/src/pages/WorkPlacePage.js
+++ b/frontend/src/pages/WorkPlacePage.js
@@ -357,7 +357,7 @@ const WorkPlacePage = () => {
   };
 
   return (
-    <WebSocketContainer spaceId={spaceId}>
+    <WebSocketContainer spaceId={spaceId} mySocketId={myUsername}>
       {({
         sendCoordinate,
         sendMessage,


### PR DESCRIPTION
exitUser 소켓 인자로 accountId를 전달하고 있었던 거여서 username을 전달하도록 webSocketContainer에 props으로 username 전달함 + EditorSocketController 백엔드 코드에서 delete하는 메소드 만든다음 해당 메소드를 WebRTCController에서 사용하도록 수정