### PR TITLE
feat : 작업실의 세마포어 생명 주기 코드 생성

### DIFF
--- a/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/semaphore/SemaphoreService.java
+++ b/backend/letsnote/src/main/java/com/geeks/letsnote/domain/studio/workSpace/semaphore/SemaphoreService.java
@@ -1,0 +1,58 @@
+package com.geeks.letsnote.domain.studio.workSpace.semaphore;
+
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+
+@Service
+public class SemaphoreService {
+
+    private final ConcurrentHashMap<String, Semaphore> workspaceSemaMap = new ConcurrentHashMap<>();
+    private final Semaphore createSema = new Semaphore(1, true);
+
+    public void acquireInitialSema() {
+        try{
+            createSema.acquire();
+        } catch (InterruptedException e){
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void releaseInitialSema() {
+        createSema.release();
+    }
+
+    public void initializeSemaphore(String spaceId) {
+        if(!workspaceSemaMap.containsKey(spaceId)){
+            Semaphore semaphore = new Semaphore(1, true); // true 파라미터는 공정한 순서로 획득
+            workspaceSemaMap.put(spaceId, semaphore);
+        }
+    }
+
+    // 세마포어 삭제
+    public void removeSemaphore(String spaceId) {
+        workspaceSemaMap.remove(spaceId);
+    }
+
+    // 세마포어 획득
+    public void acquireSemaphore(String spaceId) {
+        Semaphore semaphore = workspaceSemaMap.get(spaceId);
+        if (semaphore != null) {
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    // 세마포어 내려놓기
+    public void releaseSemaphore(String spaceId) {
+        Semaphore semaphore = workspaceSemaMap.get(spaceId);
+        if (semaphore != null) {
+            semaphore.release();
+        }
+    }
+}


### PR DESCRIPTION
1. 아무도 없는 작업실 입장 시 initSema 획득 후 spaceId에 해당하는 Semaphore 생성
2. 작업실에서 노트 클릭 시 DB 저장 로직에서 spaceId에 해당하는 Semaphore 획득 및 반납
3. 작업실의 마지막 유저가 나갈 시 Semaphore에 해당하는 Map을 삭제 -> 이후 Semaphore의 전역 선언된 데이터는 가비지 컬렉션의 대상이 되어 자동 삭제됨.