### PR TITLE
chore : isConnected가 하드코딩되어있어서 코드 안읽고 바로 렌더링하여 버그 발생

### DIFF
--- a/frontend/src/containers/workplace/WorkSpaceHeader.jsx
+++ b/frontend/src/containers/workplace/WorkSpaceHeader.jsx
@@ -256,12 +256,11 @@ const WorkSpaceHeader = ({
   };
 
   const handleMySoundMute = () => {
-    if(isDemo){
-      return;
-    }
-    localStreamRef.current
+    if(localStreamRef.current){
+      localStreamRef.current
       .getAudioTracks()
       .forEach((track) => (track.enabled = !track.enabled));
+    }
     setMySoundMuted(!mySoundMuted);
   };
 


### PR DESCRIPTION
isConnected 때문에 헤더 코드가 전부 안읽히면서 태그들의 css가 안읽힌 것 같음
isConnected를 state로 선언하도록 하여 재 렌더링 수행